### PR TITLE
Fixed formatting and make command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: make install_requirements
 
 
-make install_requirements:
-		pip install -Ur requirements.txt
+install_requirements:
+	pip install -Ur requirements.txt


### PR DESCRIPTION
Fix formatting of Makefile from tabs to 4 spaces. And changed the suggested `make install_requirements` command to simple `make`